### PR TITLE
Fix example formatting

### DIFF
--- a/src/examples/simple-example.yml
+++ b/src/examples/simple-example.yml
@@ -30,4 +30,4 @@ usage:
             plan_output_file: /tmp/workspace/terraform.plan
             pre-steps:
               - attach_workspace:
-                at: /tmp/workspace
+                  at: /tmp/workspace


### PR DESCRIPTION
The missing indent leads to a broken example once the orb development kit does its packing:

```yaml
          pre-steps:
            - at: /tmp/workspace
              attach_workspace: null
```

It should be

```yaml
          pre-steps:
              - attach_workspace:
                  at: /tmp/workspace
```