### PR TITLE
Fix Junit output

### DIFF
--- a/src/jobs/scan_terraform.yml
+++ b/src/jobs/scan_terraform.yml
@@ -28,18 +28,12 @@ parameters:
   junit-output:
     type: boolean
     default: false
-  junit-output-file:
-    description: |
-      The name of the JUnit output file. CircleCI requires JUnit output files to be in a subdirectory.
-    type: string
-    default: test_results/cloudrail-junit.xml
-
 
 steps:
   - when:
       condition: << parameters.junit-output >>
       steps:
-        - run: mkdir -p "$(dirname << parameters.junit-output-file >>)"
+        - run: mkdir -p "/tmp/junit/cloudrail"
   - scan_terraform:
       cloudrail_api_key: << parameters.cloudrail_api_key >>
       plan_output_file: << parameters.plan_output_file >>
@@ -47,9 +41,9 @@ steps:
       cloud-account-id: << parameters.cloud-account-id >>
       execution-source-identifier: << parameters.execution-source-identifier >>
       junit-output:  << parameters.junit-output >>
-      junit-output-file: << parameters.junit-output-file >>
+      junit-output-file: /tmp/junit/cloudrail/results.xml
   - when:
       condition: << parameters.junit-output >>
       steps:
         - store_test_results:
-            path: "$(dirname << parameters.junit-output-file >>)"
+            path: /tmp/junit


### PR DESCRIPTION
Previous code would give silently failing errors like:

Unable to save test results from /indeni/project/$(dirname test_results/cloudrail-junit.xml)
Error path is not valid /indeni/project/$(dirname test_results/cloudrail-junit.xml): error accessing path: /indeni/project/$(dirname test_results/cloudrail-junit.xml): lstat /indeni/project/$(dirname test_results/cloudrail-junit.xml): no such file or directory
Found no test results, skipping

We can either hardcode the junit directory name, or ask the user to
explicitly pass it in as a parameter. Since we control the executor, we
know what paths outside the working directory are safe to write junit
data too, so let's hardcode for simplicity.

This removes two parameters, which is a semver major change.

Also fixes a minor UI glitch. Putting the Junit results into
/junit/cloudrail/results.xml shows "Your build ran 71 tests in
cloudrail" (rather than "Your build ran 71 tests in unknown" from
/junit/results.xml).